### PR TITLE
Notifications to reporter not always working

### DIFF
--- a/esa.sle.java.api.core/src/main/java/esa/sle/impl/api/apipx/pxspl/EE_APIPX_Association.java
+++ b/esa.sle.java.api.core/src/main/java/esa/sle/impl/api/apipx/pxspl/EE_APIPX_Association.java
@@ -2047,10 +2047,10 @@ public abstract class EE_APIPX_Association implements ISLE_SrvProxyInitiate, ISL
                         psii = pSIAdmin.getServiceInstanceIdentifier();
                     }
                 }
-
-                this.reporter.notify(alarm, SLE_Component.sleCP_proxy, psii, messId, text);
-                this.reporter.logRecord(SLE_Component.sleCP_proxy, psii, type, messId, text);
             }
+            
+            this.reporter.notify(alarm, SLE_Component.sleCP_proxy, psii, messId, text);
+            this.reporter.logRecord(SLE_Component.sleCP_proxy, psii, type, messId, text);
         }
     }
 


### PR DESCRIPTION
When using the sle-api we noticed that errors were not always being received in our client.

Looking into the code we noticed that the reporter notifications were only being issued in case psii was null, which is not our case.

This fix makes sure the reporter is always notified.